### PR TITLE
Added Delilah to Hardware offload

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -163,6 +163,7 @@ If you are new to eBPF, you may want to try the links described as "introduction
 - [Comprehensive XDP offload---Handling the edge cases](https://www.netdevconf.org/2.2/session.html?viljoen-xdpoffload-talk) - An update on the topic above.
 - [hBPF - eBPF in hardware](https://github.com/rprinz08/hBPF) - An eBPF CPU written for FPGAs.
 - [OpenCSD eBPF SSD offloading](https://github.com/Dantali0n/qemu-csd) - Computational Storage simulation (QEMU) platform with FUSE LFS filesystem for Zoned Namespaces NVMe SSDs using uBPF for compute kernel offloading, all in userspace.
+- [Delilah: eBPF-offload on Computational Storage](https://dl.acm.org/doi/pdf/10.1145/3592980.3595319) - Delilah is a Computational Storage Processor (CSP) built for eBPF offload to storage devices.
 
 ## Tutorials
 


### PR DESCRIPTION
Delilah is the first publicly described computational storage device running eBPF. I believe it is worth mentioning.